### PR TITLE
Adding initial data to the fp widget to help with cumulative layout s…

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1331,12 +1331,40 @@ var fairplay = function(options) {
 
 	document.querySelector(el).innerHTML = document.querySelector(el).innerHTML + '<neap-widget :jobads="jobads" :filter="filter" :showjobalertbutton="showJobAlertButton"></neap-widget>'
 	
+	var placeholderJob = {
+		title: "",
+		company: "",
+		date: "",
+		summary: "",
+		bulletPoints: ["", "", ""],
+		location: {
+			name: "",
+			area: {
+				name: ""
+			},
+		},
+		salary: {
+			description: ""
+		},
+		workType: {
+			name: ""
+		},
+		profession: {
+			link: "",
+			role: {
+				link: ""
+			}
+		}
+	}
+
+	var initialJobsAds = [placeholderJob, placeholderJob, placeholderJob, placeholderJob, placeholderJob]
+
 	new Vue({
 		el: el,
 		data: {
-			allJobAds:[],
-			allFilteredJobAds:[],
-			jobads:[],
+			allJobAds:initialJobsAds,
+			allFilteredJobAds:initialJobsAds,
+			jobads:initialJobsAds,
 			filter:options.filter,
 			showJobAlertButton:options.jobAlert === undefined ? true : options.jobAlert
 		},


### PR DESCRIPTION
Hey Nic, I was thinking something like this to help with the CLS LCP scores. It's really simple - just adds initial placeholder data for the job ads (which get rendered as an empty list). 

If you pull this branch and run `npm run dev` you will get a preview of the result. The styling should look better on the client websites.

> You'll need to run project node 8.9.4 I believe

